### PR TITLE
Fixes an error that appears during installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /bronte
+/venv
+data/
+logs/
+textloader/
+__pycache__
+/checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ logs/
 textloader/
 __pycache__
 /checkpoints
+/models

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+protobuf==3.19.6
 tensorflow==1.15.4


### PR DESCRIPTION
Changes:

- `protobuf` library added to the list of dependencies. Otherwise a `protobuf requires Python '>=3.7' but the running Python is 3.6.15` error appears when installing `tensorflow`
- updated the list of temporary files and directories that should be ignored